### PR TITLE
add garm submodule for example implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "example/garm"]
+	path = example/garm
+	url = https://github.com/yahoojapan/garm


### PR DESCRIPTION
I am a software engineer from Yahoo Japan.
I implemented [garm](https://github.com/yahoojapan/garm).
The garm is a wrapper for this library. 
Could you add a submodule to example as an implementation example?