### PR TITLE
Check whether request context is done before write

### DIFF
--- a/authz.go
+++ b/authz.go
@@ -307,20 +307,26 @@ func (a *authorizer) logOutcome(logger Logger, sr *authz.SubjectAccessReviewSpec
 
 func (a *authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	sr, err := a.getSubjectAccessReview(ctx, r)
-	if err != nil {
-		getLogger(ctx).Printf("authz request error from %s: %v\n", r.RemoteAddr, err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+
+	select {
+	case <-ctx.Done():
 		return
+	default:
+		sr, err := a.getSubjectAccessReview(ctx, r)
+		if err != nil {
+			getLogger(ctx).Printf("authz request error from %s: %v\n", r.RemoteAddr, err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		gs := a.authorize(ctx, sr.Spec)
+		a.logOutcome(getLogger(ctx), &sr.Spec, gs)
+
+		resp := struct {
+			APIVersion string                          `json:"apiVersion"`
+			Kind       string                          `json:"kind"`
+			Status     authz.SubjectAccessReviewStatus `json:"status"`
+		}{sr.APIVersion, sr.Kind, gs.status}
+		writeJSON(ctx, w, &resp)
 	}
-
-	gs := a.authorize(ctx, sr.Spec)
-	a.logOutcome(getLogger(ctx), &sr.Spec, gs)
-
-	resp := struct {
-		APIVersion string                          `json:"apiVersion"`
-		Kind       string                          `json:"kind"`
-		Status     authz.SubjectAccessReviewStatus `json:"status"`
-	}{sr.APIVersion, sr.Kind, gs.status}
-	writeJSON(ctx, w, &resp)
 }

--- a/authz_test.go
+++ b/authz_test.go
@@ -134,7 +134,7 @@ type authzTestResult struct {
 	body *bytes.Buffer
 }
 
-func runAuthzTest(s *authzScaffold, input []byte, handler http.Handler) *authzTestResult {
+func runAuthzTest(s *authzScaffold, input []byte, handler http.Handler, c context.Context) *authzTestResult {
 	s.resetLog()
 	az := NewAuthorizer(s.config)
 	w := httptest.NewRecorder()
@@ -142,6 +142,9 @@ func runAuthzTest(s *authzScaffold, input []byte, handler http.Handler) *authzTe
 	w.Body = &respBody
 	r := httptest.NewRequest("POST", "/authz", bytes.NewBuffer(input))
 	s.h = handler
+	if c != nil {
+		r = r.WithContext(c)
+	}
 	az.ServeHTTP(w, r)
 	return &authzTestResult{
 		w:    w,
@@ -174,7 +177,7 @@ func TestAuthzHappyPath(t *testing.T) {
 		writeJSON(testContext, w, grant)
 	})
 	input := stdAuthzInput()
-	ar := runAuthzTest(s, serialize(input), zmsHandler)
+	ar := runAuthzTest(s, serialize(input), zmsHandler, nil)
 	w := ar.w
 	body := ar.body
 
@@ -211,7 +214,7 @@ func TestAuthzHappyPathX509(t *testing.T) {
 		writeJSON(testContext, w, grant)
 	})
 	input := stdAuthzInput()
-	ar := runAuthzTest(s, serialize(input), zmsHandler)
+	ar := runAuthzTest(s, serialize(input), zmsHandler, nil)
 	w := ar.w
 	body := ar.body
 	if w.Result().StatusCode != 200 {
@@ -250,7 +253,7 @@ func TestAuthzZMSReject(t *testing.T) {
 				writeJSON(testContext, w, grant)
 			})
 			input := stdAuthzInput()
-			ar := runAuthzTest(s, serialize(input), zmsHandler)
+			ar := runAuthzTest(s, serialize(input), zmsHandler, nil)
 			w := ar.w
 			body := ar.body
 
@@ -278,7 +281,7 @@ func TestAuthzMapperBypass(t *testing.T) {
 			nil
 	})
 	input := stdAuthzInput()
-	ar := runAuthzTest(s, serialize(input), nil)
+	ar := runAuthzTest(s, serialize(input), nil, nil)
 	w := ar.w
 	body := ar.body
 
@@ -298,7 +301,7 @@ func TestAuthzMapperError(t *testing.T) {
 			errors.New("foobar")
 	})
 	input := stdAuthzInput()
-	ar := runAuthzTest(s, serialize(input), nil)
+	ar := runAuthzTest(s, serialize(input), nil, nil)
 	w := ar.w
 	body := ar.body
 
@@ -323,7 +326,7 @@ func TestAuthzTokenErrors(t *testing.T) {
 		return "", fmt.Errorf("no token for you")
 	}
 	input := stdAuthzInput()
-	ar := runAuthzTest(s, serialize(input), nil)
+	ar := runAuthzTest(s, serialize(input), nil, nil)
 	w := ar.w
 	body := ar.body
 
@@ -348,7 +351,7 @@ func TestAuthzBadToken(t *testing.T) {
 	input := stdAuthzInput()
 	ar := runAuthzTest(s, serialize(input), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(401)
-	}))
+	}), nil)
 	w := ar.w
 	body := ar.body
 
@@ -369,7 +372,7 @@ func TestAuthzAthenz404(t *testing.T) {
 	input := stdAuthzInput()
 	ar := runAuthzTest(s, serialize(input), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(404)
-	}))
+	}), nil)
 	w := ar.w
 	body := ar.body
 
@@ -397,7 +400,7 @@ func TestAuthzAthenz500(t *testing.T) {
 	}
 	ar := runAuthzTest(s, serialize(input), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
-	}))
+	}), nil)
 	w := ar.w
 	body := ar.body
 
@@ -455,7 +458,7 @@ func TestAuthzBadInputs(t *testing.T) {
 		{400, append(serialize(base), 'X'), "invalid JSON request"},
 	}
 	for _, test := range tests {
-		ar := runAuthzTest(s, test.input, nil)
+		ar := runAuthzTest(s, test.input, nil, nil)
 		if ar.w.Code != test.code {
 			t.Fatalf("test %q: unexpected status code want %d, got %d", test.msg, test.code, ar.w.Code)
 		}
@@ -466,6 +469,33 @@ func TestAuthzBadInputs(t *testing.T) {
 				t.Errorf("response '%s' did not contain '%s'", ar.body.String(), test.msg)
 			}
 		}
+	}
+}
+
+func TestAuthzWithContextDone(t *testing.T) {
+	s := newAuthzScaffold(t)
+	defer s.Close()
+	input := stdAuthzInput()
+
+	cc, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ar := runAuthzTest(s, serialize(input), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}), cc)
+	w := ar.w
+	body := ar.body
+
+	if w.Result().StatusCode != 200 {
+		t.Fatal("invalid status code", w.Result().StatusCode)
+	}
+	bs := body.String()
+	if bs != "" {
+		t.Errorf("response body is not empty, buffer: '%s'", bs)
+	}
+	es := s.l.b.String()
+	if es != "" {
+		t.Errorf("logger buffer is not empty, buffer: '%s'", es)
 	}
 }
 

--- a/http.go
+++ b/http.go
@@ -17,14 +17,19 @@ var logKey = struct{}{}
 
 // writeJSON writes the supplied data as JSON to the response writer.
 func writeJSON(ctx context.Context, w http.ResponseWriter, data interface{}) {
-	b, err := json.Marshal(data)
-	if err != nil {
-		getLogger(ctx).Printf("internal serialization error, %v", err)
-		http.Error(w, "internal serialization error", http.StatusInternalServerError)
+	select {
+	case <-ctx.Done():
 		return
+	default:
+		b, err := json.Marshal(data)
+		if err != nil {
+			getLogger(ctx).Printf("internal serialization error, %v", err)
+			http.Error(w, "internal serialization error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(b)
 }
 
 func newReqID() string {


### PR DESCRIPTION
This PR is to avoid a panic when writing response.

# issue

When the HTTP connection is closed, the context of the request ends. Any following write action to the response writer will cause the program to panic.

# solution

Check request context before the actual write.
The current solution is try to fix the problem in the simplest way. After the context checking, there may be a small chances that the context is closed before the writing action and causes panic again.

stack trace:
```
panic: Header called after Handler finished
goroutine 1366 [running]:
net/http.(*http2responseWriter).Header(0xc0003be038, 0xc0003c4140)
        /usr/local/go/src/net/http/h2_bundle.go:6158 +0x99
github.com/yahoo/k8s-athenz-webhook.writeJSON(0xc07c00, 0xc0004a4e10, 0xc05cc0, 0xc0003be038, 0xa14d80, 0xc0003c4140)
        /go/pkg/mod/github.com/yahoo/k8s-athenz-webhook@v0.0.0-20190725182459-949d9ed74720/http.go:26 +0x1cb
github.com/yahoo/k8s-athenz-webhook.(*authorizer).ServeHTTP(0xc000212280, 0xc05cc0, 0xc0003be038, 0xc0006cc600)
        /go/pkg/mod/github.com/yahoo/k8s-athenz-webhook@v0.0.0-20190725182459-949d9ed74720/authz.go:286 +0x47f
github.com/yahoo/k8s-athenz-webhook.wrapHandler.func2(0xc05cc0, 0xc0003be038, 0xc0006cc400)
        /go/pkg/mod/github.com/yahoo/k8s-athenz-webhook@v0.0.0-20190725182459-949d9ed74720/http.go:88 +0x14f
net/http.HandlerFunc.ServeHTTP(0xc00012c6c0, 0xc05cc0, 0xc0003be038, 0xc0006cc400)
        /usr/local/go/src/net/http/server.go:2007 +0x44
github.com/yahoojapan/garm/service.(*athenz).AthenzAuthorizer(0xc00014b0e0, 0xc05cc0, 0xc0003be038, 0xc0006cc400, 0xc0001fa1c0, 0xc05cc0)
        /go/src/github.com/yahoojapan/garm/service/athenz.go:88 +0x58
github.com/yahoojapan/garm/handler.(*handler).Authorize(0xc000289010, 0xc05cc0, 0xc0003be038, 0xc0006cc400, 0xc0003be001, 0xc000120800)
        /go/src/github.com/yahoojapan/garm/handler/handlers.go:59 +0x55
github.com/yahoojapan/garm/router.routing.func1.1(0xc0001250e0, 0xc000239120, 0xc05cc0, 0xc0003be038, 0xc0006cc300, 0xc07bc0, 0xc0006547e0)
        /go/src/github.com/yahoojapan/garm/router/router.go:81 +0xed
created by github.com/yahoojapan/garm/router.routing.func1
        /go/src/github.com/yahoojapan/garm/router/router.go:79 +0x491
```

similar issue: https://github.com/kubernetes/kubernetes/issues/29001

> I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.