### PR TITLE
update SubjectAccessReviewSpec from v1beta to v1

### DIFF
--- a/api.go
+++ b/api.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"time"
 
-	authn "k8s.io/api/authentication/v1beta1"
-	authz "k8s.io/api/authorization/v1beta1"
+	authn "k8s.io/api/authentication/v1"
+	authz "k8s.io/api/authorization/v1"
 
 	"github.com/yahoo/athenz/libs/go/zmssvctoken"
 )

--- a/api_test.go
+++ b/api_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	authn "k8s.io/api/authentication/v1beta1"
-	authz "k8s.io/api/authorization/v1beta1"
+	authn "k8s.io/api/authentication/v1"
+	authz "k8s.io/api/authorization/v1"
 )
 
 func TestAPIAccessCheckString(t *testing.T) {

--- a/authn.go
+++ b/authn.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	authn "k8s.io/api/authentication/v1beta1"
+	authn "k8s.io/api/authentication/v1"
 )
 
 const (

--- a/authn_test.go
+++ b/authn_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	authn "k8s.io/api/authentication/v1beta1"
+	authn "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/require"

--- a/authz.go
+++ b/authz.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	authz "k8s.io/api/authorization/v1beta1"
+	authz "k8s.io/api/authorization/v1"
 )
 
 const (

--- a/authz_test.go
+++ b/authz_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	authz "k8s.io/api/authorization/v1beta1"
+	authz "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/example/auth-webhook/main_test.go
+++ b/example/auth-webhook/main_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	authn "k8s.io/api/authentication/v1beta1"
-	authz "k8s.io/api/authorization/v1beta1"
+	authn "k8s.io/api/authentication/v1"
+	authz "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 

--- a/example/auth-webhook/mapping.go
+++ b/example/auth-webhook/mapping.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	api "github.com/yahoo/k8s-athenz-webhook"
-	authn "k8s.io/api/authentication/v1beta1"
-	authz "k8s.io/api/authorization/v1beta1"
+	authn "k8s.io/api/authentication/v1"
+	authz "k8s.io/api/authorization/v1"
 )
 
 // this file contains implementations for the user mapper,
@@ -66,7 +66,6 @@ func isSystemNamespace(ns string) bool {
 //
 // - for read access, adds a secondary auth checks for cluster admin access so that these roles
 // have full read access on all resources in all namespaces.
-//
 type ResourceMapper struct {
 	AdminDomain    string   // the admin domain to use for system resources
 	AdminResources []string // namespaced resourced that should be treated as system resources for write
@@ -92,7 +91,6 @@ func RestoreDomainName(ns string) string {
 // under the admin domain.
 //
 // - all other namespaces are returned as is, modified for k8s to Athenz differences.
-//
 func (d *ResourceMapper) DomainFromNamespace(ns string) string {
 	if ns == "" {
 		return d.AdminDomain
@@ -108,7 +106,6 @@ func (d *ResourceMapper) DomainFromNamespace(ns string) string {
 // - service accounts are turned into Athenz services in the mapped domain of the service account namespace.
 //
 // - Non-service accounts are returned unmodified
-//
 func (d *ResourceMapper) PrincipalFromUser(user string) string {
 	if strings.HasPrefix(user, serviceAccountPrefix) {
 		u := strings.TrimPrefix(user, serviceAccountPrefix)

--- a/example/auth-webhook/mapping_test.go
+++ b/example/auth-webhook/mapping_test.go
@@ -16,8 +16,8 @@ import (
 	"io/ioutil"
 
 	api "github.com/yahoo/k8s-athenz-webhook"
-	authn "k8s.io/api/authentication/v1beta1"
-	authz "k8s.io/api/authorization/v1beta1"
+	authn "k8s.io/api/authentication/v1"
+	authz "k8s.io/api/authorization/v1"
 )
 
 var testContext = context.Background()


### PR DESCRIPTION
related PR: https://github.com/yahoo/k8s-athenz-webhook/pull/28

Update the underlying spec definition from `v1beta` to `v1` too.
- breaking changes in spec: `group` => `groups`
    - https://github.com/kubernetes/api/blob/f6996b4b8b8b5db415a11bce90d01539e0ae8f43/authorization/v1beta1/types.go#L155
    - https://github.com/kubernetes/api/blob/f6996b4b8b8b5db415a11bce90d01539e0ae8f43/authorization/v1/types.go#L146

> I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
